### PR TITLE
embed周りをリファクタリング

### DIFF
--- a/Data.py
+++ b/Data.py
@@ -22,9 +22,3 @@ OBSERVER_HELP_DICT = {
   "observer chat-ranking": "チャット数ランキングを表示します",
   "observer member": "サーバーのメンバーを表示します",
 }
-
-EMBED_COLOR_WHITE = 0xF0F0FF
-EMBED_COLOR_YELLOW = 0xFFFF00
-EMBED_COLOR_RED = 0xFF0000
-EMBED_COLOR_GREEN = 0x00FF00
-BASE_EMBED = discord.Embed(title = "Observer", color = EMBED_COLOR_WHITE)

--- a/Data.py
+++ b/Data.py
@@ -1,6 +1,5 @@
 from dotenv import load_dotenv
 import os
-import discord
 
 load_dotenv()
 

--- a/Other.py
+++ b/Other.py
@@ -1,5 +1,6 @@
 from unicodedata import east_asian_width # 全角半角判定用
 from math import isqrt
+import discord
 
 def check_width(string) -> int:
   "全角の文字を2文字としてカウントした文字数を返す"
@@ -14,3 +15,25 @@ def check_width(string) -> int:
 def return_level_up_cnt(level, chat, length):
   new_level = isqrt(chat + (length // 10))
   return new_level - level
+
+
+def make_embed(color = "white", description = "") -> discord.Embed:
+  # Embedのカラー
+  COLOR_DICT = {
+    "white": 0xF0F0FF,
+    "yellow": 0xFFFF00,
+    "red": 0xFF0000,
+    "green": 0x00FF00
+  }
+  
+  embed = discord.Embed(title = "Observer")
+  
+  if color in COLOR_DICT.keys():
+    embed.color = COLOR_DICT[color]
+  else:
+    embed.color = COLOR_DICT["white"]
+    print(f"Warning: color '{color}' not found.")
+  
+  embed.description = description
+
+  return embed

--- a/observer.py
+++ b/observer.py
@@ -11,7 +11,8 @@ database = database_manager.Database(Data.MONGODB_URI, "discord", "user-data")
 
 # コマンドの関数
 async def help(message):
-  embed = Data.BASE_EMBED.copy()
+  print("help")
+  embed = Other.make_embed()
   for command, description in Data.OBSERVER_HELP_DICT.items():
     embed.add_field(name = command, value = description, inline = False)
   await message.channel.send(embed = embed)
@@ -26,14 +27,10 @@ async def data(message, id):
     text += f"・合計チャット数：{data['chat']}\n"
     text += f"・合計文字数　　：{data['length']}\n"
     text += "="* (20 + len(data['name']))
-    embed = Data.BASE_EMBED.copy()
-    embed.description = text
-    await message.channel.send(embed = embed)
+    embed = Other.make_embed(description=text)
   else:
-    embed = Data.BASE_EMBED.copy()
-    embed.color = Data.EMBED_COLOR_RED
-    embed.description = f"「{id}」のデータは見つかりませんでした。"
-    await message.channel.send(embed = embed)
+    embed = Other.make_embed("red", f"「{id}」のデータは見つかりませんでした。")
+  await message.channel.send(embed = embed)
 
 async def data_all(message):
   for member in message.guild.members:
@@ -49,8 +46,7 @@ async def chat_ranking(message):
   for i, (name, chat) in enumerate(chat_data):
     text += f"　第{i+1}位：{name}（{chat}回）\n"
   text += "=" * (20 + 1 + len("チャット数ランキング"))
-  embed = Data.BASE_EMBED.copy()
-  embed.description = text
+  embed = Other.make_embed(description=text)
   await message.channel.send(embed = embed)
 
 async def member(message):
@@ -102,8 +98,7 @@ async def member(message):
   output_text += text
   output_text += "=" * (max_string_length - 1)
   
-  embed = Data.BASE_EMBED.copy()
-  embed.description = output_text
+  embed = Other.make_embed(description=output_text)
   await message.channel.send(embed = embed)
 
 # コマンドのルーティング
@@ -119,17 +114,13 @@ async def router(message, command):
   elif command[1] == "member":
     await member(message)
   else:
-    embed = Data.BASE_EMBED.copy()
-    embed.color = Data.EMBED_COLOR_RED
-    embed.description = "無効なコマンドです。\n`observer help`でヘルプを表示できます。"
+    embed = Other.make_embed("red", description="無効なコマンドです。\n`observer help`でヘルプを表示できます。")
     await message.channel.send(embed = embed)
 
 # アドミンコマンドのルーティング
 async def admin_router(message, command):
   if command[1] == "logout":
-    embed = Data.BASE_EMBED.copy()
-    embed.description = "終了します。"
-    embed.color = Data.EMBED_COLOR_YELLOW
+    embed = Other.make_embed("yellow", "終了します。")
     channel = discord_client.get_channel(Data.BOT_LOG_CHANNEL_ID)
     await channel.send(embed = embed)
     await discord_client.close()
@@ -138,9 +129,7 @@ async def admin_router(message, command):
 @discord_client.event
 async def on_ready():
   print('Log in : Observer', flush = True)
-  embed = Data.BASE_EMBED.copy()
-  embed.description = "起動しました。"
-  embed.color = Data.EMBED_COLOR_YELLOW
+  embed = Other.make_embed("yellow", "起動しました。")
   channel = discord_client.get_channel(Data.BOT_LOG_CHANNEL_ID)
   await channel.send(embed = embed)
 
@@ -175,9 +164,7 @@ async def on_message(message):
   level_up_cnt = Other.return_level_up_cnt(level, chat, length)
   if level_up_cnt > 0: # レベルアップした場合
     database.update_level(author.name, level_up_cnt)
-    embed = Data.BASE_EMBED.copy()
-    embed.color = Data.EMBED_COLOR_GREEN
-    embed.description = f"{author.name}がレベルアップしました！（Lv:{level} → Lv:{level+level_up_cnt}）"
+    embed = Other.make_embed("green", f"{author.name}がレベルアップしました！（Lv:{level} → Lv:{level+level_up_cnt}）")
     await message.channel.send(embed = embed)
   database.log()
   
@@ -185,9 +172,7 @@ async def on_message(message):
   if content_split[0] == "observer" and len(content_split) >= 2:
     await router(message, content_split)
   elif content_split[0] == "observer":
-    embed = Data.BASE_EMBED.copy()
-    embed.color = Data.EMBED_COLOR_RED
-    embed.description = "無効なコマンドです。\n`observer help`でヘルプを表示できます。"
+    embed = Other.make_embed("red", "無効なコマンドです。\n`observer help`でヘルプを表示できます。")
     await message.channel.send(embed = embed)
 
 def main():


### PR DESCRIPTION
各処理の度にembedをcopyして数行のコードを書いていて冗長だったので関数化しました。
```python
embed = Other.make_embed("red", f"「{id}」のデータは見つかりませんでした。")
```
のように一行でembedを作成できます。
また、この更新に伴いembedの処理が書かれている部分は一通りこの書き方に更新しました。
表面上の挙動は変わりません。一通り動作確認済みです！